### PR TITLE
LDAP search before bind and LDAPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ Meteor.loginWithLDAP(username, password, {
 Issues + Notes
 -----
 * If your app requires that only LDAP authorized users should be able to login, it is strongly recommended that you
-include the following server-side code to prevent a user from gaining access through Accounts.createUser(), which will
-otherwise automatically login a newly created (non-LDAP) user:
+include the following server-side code to prevent a user from gaining access through Accounts.createUser() on the client, which will otherwise automatically login a newly created (non-LDAP) user:
 ```
 //on the server
 Meteor.startup(function () {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ user.profile = {
 }
 ```
 
+`LDAP_DEFAULTS.base`: This is the base dn used for searches if the searchResultsProfileMap is set.
 
 #### Client Side Configuration
 
@@ -64,7 +65,10 @@ Meteor.loginWithLDAP(username, password, {
     // The dn value depends on what you want to search/auth against
     // The structure will depend on how your ldap server
     // is configured or structured.
-  dn: "uid=" + username + ",cn=users,dc=whatever,dc=valuesyouneed"
+  dn: "uid=" + username + ",cn=users,dc=whatever,dc=valuesyouneed",
+    // The search value is optional. Set it if your search does not
+    // work with the bind dn.
+  search: "(objectclass=*)"
 }, function(err) {
   if (err)
     console.log(err.reason);
@@ -77,6 +81,24 @@ Issues + Notes
 * The LDAP dn is specific to your Active Directory. Talk to whoever manages it to figure out what would work best.
 * ***Because the package binds/authenticates with LDAP server-side, the user/password are sent to the server unencrypted. I still need to figure out a solution for this.***
 * Right now Node throws a warning on meteor startup: `{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }` because optional dependencies are missing. It doesn't seem to affect the ldapjs functionality, but I'm still trying to figure out how to squelch it. See [this thread](https://github.com/mcavage/node-ldapjs/issues/64). As a workaround, you can re-install the included dtrace-provider NPM package: `<project-root>/.meteor/local/build/programs/server/npm/typ_ldapjs/node_modules/ldapjs$ sudo npm install dtrace-provider`
+
+
+Active Directory
+-----
+
+Using AD you can bind using domain\username. This example works for me:
+
+```
+//on the server
+LDAP_DEFAULTS.base = 'OU=User,DC=your,DC=company,DC=com';
+
+//on the client
+var domain = "yourDomain";
+
+Meteor.loginWithLDAP(user, password, 
+  { dn: domain + '\\' + user, search: '(sAMAccountName=' + user + ')' } , function(err, result) { ... }
+);
+```
 
 
 Going Forward

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The package exposes a global variable called `LDAP_DEFAULTS` on the server side.
 
 `LDAP_DFAULTS.defaultDomain`: Specify the email domain to be used when creating a new user on login. Defaults to `false` - so if the user has entered xyz@site.com and `defaultDomain` is not set, then their email will be saved as xyz@site.com.
 
-`LDAP_DEFAULTS.searchResultsProfileMap`: This can be used if there are attributes at your specified dn that you'd like to use to set properties when creating a new user's profile. 
+`LDAP_DEFAULTS.searchResultsProfileMap`: This can be used if there are attributes at your specified dn that you'd like to use to set properties when creating a new user's profile.
 
 For example, if the results had a 'cn' value of the user's name and a 'tn' value of their phone number, you'd set the `searchResultsProfileMap` to this:
 
@@ -77,7 +77,16 @@ Meteor.loginWithLDAP(username, password, {
 
 Issues + Notes
 -----
-
+* If your app requires that only LDAP authorized users should be able to login, it is strongly recommended that you \
+include the following server-side code to prevent a user from gaining access through Accounts.createUser(), which will \
+otherwise automatically login a newly created (non-LDAP) user:
+```
+Meteor.startup(function () {
+  Accounts.config({
+  	forbidClientAccountCreation: true
+  });
+});
+```
 * The LDAP dn is specific to your Active Directory. Talk to whoever manages it to figure out what would work best.
 * ***Because the package binds/authenticates with LDAP server-side, the user/password are sent to the server unencrypted. I still need to figure out a solution for this.***
 * Right now Node throws a warning on meteor startup: `{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }` because optional dependencies are missing. It doesn't seem to affect the ldapjs functionality, but I'm still trying to figure out how to squelch it. See [this thread](https://github.com/mcavage/node-ldapjs/issues/64). As a workaround, you can re-install the included dtrace-provider NPM package: `<project-root>/.meteor/local/build/programs/server/npm/typ_ldapjs/node_modules/ldapjs$ sudo npm install dtrace-provider`
@@ -95,7 +104,7 @@ LDAP_DEFAULTS.base = 'OU=User,DC=your,DC=company,DC=com';
 //on the client
 var domain = "yourDomain";
 
-Meteor.loginWithLDAP(user, password, 
+Meteor.loginWithLDAP(user, password,
   { dn: domain + '\\' + user, search: '(sAMAccountName=' + user + ')' } , function(err, result) { ... }
 );
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Issues + Notes
 
 * The LDAP dn is specific to your Active Directory. Talk to whoever manages it to figure out what would work best.
 * ***Because the package binds/authenticates with LDAP server-side, the user/password are sent to the server unencrypted. I still need to figure out a solution for this.***
-* Right now Node throws a warning on meteor startup: `{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }` because optional dependencies are missing. It doesn't seem to affect the ldapjs functionality, but I'm still trying to figure out how to squelch it. See [this thread](https://github.com/mcavage/node-ldapjs/issues/64).
+* Right now Node throws a warning on meteor startup: `{ [Error: Cannot find module './build/Debug/DTraceProviderBindings'] code: 'MODULE_NOT_FOUND' }` because optional dependencies are missing. It doesn't seem to affect the ldapjs functionality, but I'm still trying to figure out how to squelch it. See [this thread](https://github.com/mcavage/node-ldapjs/issues/64). As a workaround, you can re-install the included dtrace-provider NPM package: `<project-root>/.meteor/local/build/programs/server/npm/typ_ldapjs/node_modules/ldapjs$ sudo npm install dtrace-provider`
 
 
 Going Forward

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ Meteor.loginWithLDAP(username, password, {
 
 Issues + Notes
 -----
-* If your app requires that only LDAP authorized users should be able to login, it is strongly recommended that you \
-include the following server-side code to prevent a user from gaining access through Accounts.createUser(), which will \
+* If your app requires that only LDAP authorized users should be able to login, it is strongly recommended that you
+include the following server-side code to prevent a user from gaining access through Accounts.createUser(), which will
 otherwise automatically login a newly created (non-LDAP) user:
 ```
+//on the server
 Meteor.startup(function () {
   Accounts.config({
   	forbidClientAccountCreation: true

--- a/ldap_server.js
+++ b/ldap_server.js
@@ -10,7 +10,9 @@ LDAP_DEFAULTS = {
 	dn: false,
 	createNewUser: true,
 	defaultDomain: false,
-	searchResultsProfileMap: false
+	searchResultsProfileMap: false,
+	base: null,
+	search: '(objectclass=*)'
 };
 
 /**
@@ -95,7 +97,23 @@ LDAP.prototype.ldapCheck = function(options) {
 
 					// Return search results if specified
 					if (self.options.searchResultsProfileMap) {
-						client.search(self.options.dn, {}, function(err, res) {
+
+						// construct list of ldap attributes to fetch
+						var attributes = [];
+						self.options.searchResultsProfileMap.map(function(item) {
+							attributes.push(item.resultKey);
+						});
+
+						// use base if given, else the dn for the ldap search
+						var searchBase = self.options.base || self.options.dn;
+						var searchOptions = {
+							scope: 'sub',
+							sizeLimit: 1,
+							attributes: attributes,
+							filter: self.options.search
+						}
+
+						client.search(searchBase, searchOptions, function(err, res) {
 
 							res.on('searchEntry', function(entry) {
 								// Add entry results to return object


### PR DESCRIPTION
I added another option `searchBeforeBind` to the client-side call `loginWithLdap` in case the `dn` is not known or cannot be determined from the login name.

If no `dn` is configured or provided, the server-side logic will first call an LDAP search with the provided search parameters (+ configured search base) to determine the record containing the `dn`. Then the standard bind is performed using the password provided using the `dn`.

When the LDAP client is initialised I also added support to provide an SSL certificate to the client to comply with more strict security regulations and support `ldaps://` support.
